### PR TITLE
feat: Use http data query to update DNS record.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,12 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
+      TF_INPUT: 0
+
+      TF_VAR_google_domains_dynamic_dns_api_password: ${{ secrets.TF_VAR_GOOGLE_DOMAINS_DYNAMIC_DNS_API_PASSWORD }}
+      TF_VAR_google_domains_dynamic_dns_api_username: ${{ secrets.TF_VAR_GOOGLE_DOMAINS_DYNAMIC_DNS_API_USERNAME }}
       TF_VAR_public_key: ${{ secrets.TF_VAR_PUBLIC_KEY }}
-      TF_VAR_username: ${{ secrets.TF_VAR_USERNAME}}
+      TF_VAR_username: ${{ secrets.TF_VAR_USERNAME }}
 
     environment: Production
     needs:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,6 +11,10 @@ terraform {
     azurerm = {
       source = "hashicorp/azurerm"
     }
+
+    http = {
+      source = "hashicorp/http"
+    }
   }
 }
 
@@ -124,4 +128,8 @@ resource "azurerm_linux_virtual_machine" "linux_virtual_machine" {
     sku       = data.azurerm_platform_image.platform_image.sku
     version   = data.azurerm_platform_image.platform_image.version
   }
+}
+
+data "http" "dns_record_http" {
+  url = "https://${var.google_domains_dynamic_dns_api_username}:${var.google_domains_dynamic_dns_api_password}@domains.google.com/nic/update?hostname=${var.hostname}.com&myip=${azurerm_public_ip.public_ip.ip_address}"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,21 @@
+variable "hostname" {
+  default     = "starsandmanifolds.xy"
+  description = "The hostname used for the DNS A record."
+  type        = string
+}
+
+variable "google_domains_dynamic_dns_api_username" {
+  description = "The username for the Dynamic DNS API on Google Domains."
+  sensitive   = true
+  type        = string
+}
+
+variable "google_domains_dynamic_dns_api_password" {
+  description = "The password for the Dynamic DNS API on Google Domains."
+  sensitive   = true
+  type        = string
+}
+
 variable "location" {
   default     = "EastUS"
   description = "The region where the resources exist."


### PR DESCRIPTION
# Summary

Use the `hashicorp/http` provider to send a GET request Google Domains to update the Dynamic DNS record so that it points the root domain to the virtual machine's IP address. The URL is of the form:

`https://$USERNAME:$PASSWORD@domains.google.com/nic/update?hostname=$HOSTNAME&myip=$IP_ADDRESS`